### PR TITLE
Fix `unmount` prop element position breaking

### DIFF
--- a/packages/vue/src/float.ts
+++ b/packages/vue/src/float.ts
@@ -435,14 +435,21 @@ export const Float = defineComponent({
 
           renderPortal(
             renderFloating(
-              h(Transition, transitionProps, () =>
-                (typeof props.show === 'boolean'
-                  ? props.show
-                  : true
-                )
-                  ? cloneVNode(floatingNode, props.floatingAs === 'template' ? floatingProps : null)
-                  : createCommentVNode()
-              )
+              h(Transition, transitionProps, () => {
+                const contentProps = props.floatingAs === 'template' ? floatingProps : null
+                const el = cloneVNode(floatingNode, contentProps)
+
+                if (el.props?.unmount === false) {
+                  updateElements()
+                  updateFloating()
+                  return el
+                }
+
+                if (typeof props.show === 'boolean' ? props.show : true) {
+                  return el
+                }
+                return createCommentVNode()
+              })
             )
           ),
         ])


### PR DESCRIPTION
close #19

Although this PR fixes the element position, the use of `unmount` will make the transition unable to work properly because I cannot operate inside the components of the Headless UI. Unless you have special needs, it is not recommended to use `unmount`. If you really need it, it is recommended to use `static` to customize, or give up using Headless UI Float and use CSS for positioning.