### PR TITLE
Hydration fix for Next.js

### DIFF
--- a/packages/react/src/float.tsx
+++ b/packages/react/src/float.tsx
@@ -324,7 +324,7 @@ const FloatRoot = forwardRef<ElementType, FloatProps>((props, ref) => {
       }),
       width: props.adaptiveWidth && typeof referenceElWidth === 'number'
         ? `${referenceElWidth}px`
-        : '',
+        : undefined,
     },
   }
 


### PR DESCRIPTION
Using Next.js, a hydration error is given when using the library. A part of the error:

```txt
Warning: Prop `style` did not match. Server: "position:absolute;z-index:9999;top:0;left:0;right:auto;bottom:auto;transform:translate(0px,0px)" Client: "position:absolute;z-index:9999;top:0;left:0;right:auto;bottom:auto;transform:translate(0px,0px);width:"
    at div
    at span
    at eval
...
```

The width style is now set to `undefined` so client hydration matches server. This resolves the error in Next.js.

Also, love the library! It has saved me a bunch of time setting up Headless UI / Floating UI.