### PR TITLE
fix: blurry text on browser zoom

### DIFF
--- a/packages/react/src/float.tsx
+++ b/packages/react/src/float.tsx
@@ -202,11 +202,10 @@ export function renderFloatingElement(
       ...((props.dialog ? false : (props.transform || props.transform === undefined)) ? {
         position: strategy,
         zIndex: props.zIndex || 9999,
-        top: '0px',
-        left: '0px',
+        top: y || 0,
+        left: x || 0,
         right: 'auto',
         bottom: 'auto',
-        transform: `translate(${Math.round(x || 0)}px,${Math.round(y || 0)}px)`,
       } : {
         position: strategy,
         zIndex: props.zIndex || 9999,


### PR DESCRIPTION
If you zoom out in the browser on some devices, floating items are blurred.

description of the issue: https://github.com/floating-ui/floating-ui/issues/779

mention of blurriness in floating-ui docs: https://floating-ui.com/docs/misc#subpixel-and-accelerated-positioning

> x and y can contain fractional numbers (decimal), so there will be blurring unless we place it evenly on the device’s pixel grid. The rounding method above ensures the floating element is positioned optimally for the screen.

fixing with basic floating-ui example: https://floating-ui.com/docs/react#positioning