### PR TITLE
Support RTL for tailwind css origin class resolver

### DIFF
--- a/packages/react/src/class-resolvers/index.ts
+++ b/packages/react/src/class-resolvers/index.ts
@@ -1,2 +1,3 @@
 export * from './tailwindcss'
+export * from './tailwindcss-rtl'
 export * from './type'

--- a/packages/react/src/class-resolvers/tailwindcss-rtl.ts
+++ b/packages/react/src/class-resolvers/tailwindcss-rtl.ts
@@ -1,0 +1,39 @@
+import type { ClassResolver } from './type'
+
+export const tailwindcssRtlOriginSafelist = [
+  'origin-bottom',
+  'origin-top',
+  'ltr:origin-right rtl:origin-left',
+  'ltr:origin-left rtl:origin-right',
+  'ltr:origin-bottom-left rtl:origin-bottom-right',
+  'ltr:origin-bottom-right rtl:origin-bottom-left',
+  'ltr:origin-top-left rtl:origin-top-right',
+  'ltr:origin-top-right rtl:origin-top-left',
+]
+
+export const tailwindcssRtlOriginClassResolver: ClassResolver = placement => {
+  switch (placement) {
+    case 'top':
+      return 'origin-bottom'
+    case 'bottom':
+      return 'origin-top'
+    case 'left':
+      return 'ltr:origin-right rtl:origin-left'
+    case 'right':
+      return 'ltr:origin-left rtl:origin-right'
+    case 'top-start':
+    case 'right-end':
+      return 'ltr:origin-bottom-left rtl:origin-bottom-right'
+    case 'top-end':
+    case 'left-end':
+      return 'ltr:origin-bottom-right rtl:origin-bottom-left'
+    case 'right-start':
+    case 'bottom-start':
+      return 'ltr:origin-top-left rtl:origin-top-right'
+    case 'left-start':
+    case 'bottom-end':
+      return 'ltr:origin-top-right rtl:origin-top-left'
+    default:
+      return 'origin-center'
+  }
+}

--- a/packages/react/src/class-resolvers/tailwindcss.ts
+++ b/packages/react/src/class-resolvers/tailwindcss.ts
@@ -34,6 +34,6 @@ export const tailwindcssOriginClassResolver: ClassResolver = placement => {
     case 'bottom-end':
       return 'origin-top-right'
     default:
-      return ''
+      return 'origin-center'
   }
 }

--- a/packages/vue/src/class-resolvers/index.ts
+++ b/packages/vue/src/class-resolvers/index.ts
@@ -1,2 +1,3 @@
 export * from './tailwindcss'
+export * from './tailwindcss-rtl'
 export * from './type'

--- a/packages/vue/src/class-resolvers/tailwindcss-rtl.ts
+++ b/packages/vue/src/class-resolvers/tailwindcss-rtl.ts
@@ -1,0 +1,39 @@
+import type { ClassResolver } from './type'
+
+export const tailwindcssRtlOriginSafelist = [
+  'origin-bottom',
+  'origin-top',
+  'ltr:origin-right rtl:origin-left',
+  'ltr:origin-left rtl:origin-right',
+  'ltr:origin-bottom-left rtl:origin-bottom-right',
+  'ltr:origin-bottom-right rtl:origin-bottom-left',
+  'ltr:origin-top-left rtl:origin-top-right',
+  'ltr:origin-top-right rtl:origin-top-left',
+]
+
+export const tailwindcssRtlOriginClassResolver: ClassResolver = placement => {
+  switch (placement) {
+    case 'top':
+      return 'origin-bottom'
+    case 'bottom':
+      return 'origin-top'
+    case 'left':
+      return 'ltr:origin-right rtl:origin-left'
+    case 'right':
+      return 'ltr:origin-left rtl:origin-right'
+    case 'top-start':
+    case 'right-end':
+      return 'ltr:origin-bottom-left rtl:origin-bottom-right'
+    case 'top-end':
+    case 'left-end':
+      return 'ltr:origin-bottom-right rtl:origin-bottom-left'
+    case 'right-start':
+    case 'bottom-start':
+      return 'ltr:origin-top-left rtl:origin-top-right'
+    case 'left-start':
+    case 'bottom-end':
+      return 'ltr:origin-top-right rtl:origin-top-left'
+    default:
+      return 'origin-center'
+  }
+}

--- a/packages/vue/src/class-resolvers/tailwindcss.ts
+++ b/packages/vue/src/class-resolvers/tailwindcss.ts
@@ -34,6 +34,6 @@ export const tailwindcssOriginClassResolver: ClassResolver = placement => {
     case 'bottom-end':
       return 'origin-top-right'
     default:
-      return ''
+      return 'origin-center'
   }
 }


### PR DESCRIPTION
Fix #63

### Usage

You must be set the `tailwindcssRtlOriginSafelist` into `tailwind.config.js`'s safelist:

*tailwind.config.js*
```js
import { tailwindcssRtlOriginSafelist } from '@headlessui-float/vue'

/** @type {import('tailwindcss').Config} */
export default {
  safelist: [...tailwindcssRtlOriginSafelist],
}
```

Using with react:

```jsx
import { Float, tailwindcssRtlOriginClassResolver } from '@headlessui-float/react'

export default function ExampleRtlOriginClass() {
  return (
    <Float originClass={tailwindcssRtlOriginClassResolver}>
  )
}
```

Using with vue:

```vue
<template>
  <Float :origin-class="tailwindcssRtlOriginClassResolver">
</template>

<script setup>
import { Float, tailwindcssRtlOriginClassResolver } from '@headlessui-float/vue'
</script>
```