### PR TITLE
Change `transform` default to `false`

### DIFF
--- a/examples/example-react-ts/src/pages/floatingui-options.tsx
+++ b/examples/example-react-ts/src/pages/floatingui-options.tsx
@@ -50,7 +50,7 @@ function ExamplePlacement() {
       }
     >
       <Menu>
-        <Float show placement={placement} zIndex={99}>
+        <Float show placement={placement} zIndex={99} transform>
           <Menu.Button className="flex justify-center items-center px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
             Options
           </Menu.Button>
@@ -109,7 +109,7 @@ function ExampleOffset() {
       }
     >
       <Menu>
-        <Float show placement="bottom-start" offset={offset} zIndex={99}>
+        <Float show placement="bottom-start" offset={offset} zIndex={99} transform>
           <Menu.Button className="flex justify-center items-center mx-auto px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
             Options
           </Menu.Button>
@@ -169,7 +169,7 @@ function ExampleShift() {
     >
       <div className="h-[800px] pt-[382px]">
         <Menu>
-          <Float show placement="right" shift={shift} zIndex={99}>
+          <Float show placement="right" shift={shift} zIndex={99} transform>
             <Menu.Button className="flex justify-center items-center mx-auto px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
               Options
             </Menu.Button>
@@ -230,7 +230,7 @@ function ExampleFlip() {
     >
       <div className="h-[800px] pt-[382px]">
         <Menu>
-          <Float show placement="bottom" flip={flip} zIndex={99}>
+          <Float show placement="bottom" flip={flip} zIndex={99} transform>
             <Menu.Button className="flex justify-center items-center mx-auto px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
               Options
             </Menu.Button>

--- a/examples/example-react/src/pages/floatingui-options.jsx
+++ b/examples/example-react/src/pages/floatingui-options.jsx
@@ -49,7 +49,7 @@ function ExamplePlacement() {
       }
     >
       <Menu>
-        <Float show placement={placement} zIndex={99}>
+        <Float show placement={placement} zIndex={99} transform>
           <Menu.Button className="flex justify-center items-center px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
             Options
           </Menu.Button>
@@ -108,7 +108,7 @@ function ExampleOffset() {
       }
     >
       <Menu>
-        <Float show placement="bottom-start" offset={offset} zIndex={99}>
+        <Float show placement="bottom-start" offset={offset} zIndex={99} transform>
           <Menu.Button className="flex justify-center items-center mx-auto px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
             Options
           </Menu.Button>
@@ -168,7 +168,7 @@ function ExampleShift() {
     >
       <div className="h-[800px] pt-[382px]">
         <Menu>
-          <Float show placement="right" shift={shift} zIndex={99}>
+          <Float show placement="right" shift={shift} zIndex={99} transform>
             <Menu.Button className="flex justify-center items-center mx-auto px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
               Options
             </Menu.Button>
@@ -229,7 +229,7 @@ function ExampleFlip() {
     >
       <div className="h-[800px] pt-[382px]">
         <Menu>
-          <Float show placement="bottom" flip={flip} zIndex={99}>
+          <Float show placement="bottom" flip={flip} zIndex={99} transform>
             <Menu.Button className="flex justify-center items-center mx-auto px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
               Options
             </Menu.Button>

--- a/examples/example-vue-ts/src/pages/floatingui-options.vue
+++ b/examples/example-vue-ts/src/pages/floatingui-options.vue
@@ -23,7 +23,7 @@
     </template>
 
     <Menu>
-      <Float show :placement="placement" z-index="99">
+      <Float show :placement="placement" z-index="99" transform>
         <MenuButton class="flex justify-center items-center px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
           Options
         </MenuButton>
@@ -60,7 +60,7 @@
     </template>
 
     <Menu>
-      <Float show placement="bottom-start" :offset="offset" z-index="99">
+      <Float show placement="bottom-start" :offset="offset" z-index="99" transform>
         <MenuButton class="flex justify-center items-center mx-auto px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
           Options
         </MenuButton>
@@ -98,7 +98,7 @@
 
     <div class="h-[800px] pt-[382px]">
       <Menu>
-        <Float show placement="right" :shift="shift" z-index="99">
+        <Float show placement="right" :shift="shift" z-index="99" transform>
           <MenuButton class="flex justify-center items-center mx-auto px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
             Options
           </MenuButton>
@@ -137,7 +137,7 @@
 
     <div class="h-[800px] pt-[382px]">
       <Menu>
-        <Float show placement="bottom" :flip="flip" z-index="99">
+        <Float show placement="bottom" :flip="flip" z-index="99" transform>
           <MenuButton class="flex justify-center items-center mx-auto px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
             Options
           </MenuButton>

--- a/examples/example-vue/src/pages/floatingui-options.vue
+++ b/examples/example-vue/src/pages/floatingui-options.vue
@@ -23,7 +23,7 @@
     </template>
 
     <Menu>
-      <Float show :placement="placement" z-index="99">
+      <Float show :placement="placement" z-index="99" transform>
         <MenuButton class="flex justify-center items-center px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
           Options
         </MenuButton>
@@ -60,7 +60,7 @@
     </template>
 
     <Menu>
-      <Float show placement="bottom-start" :offset="offset" z-index="99">
+      <Float show placement="bottom-start" :offset="offset" z-index="99" transform>
         <MenuButton class="flex justify-center items-center mx-auto px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
           Options
         </MenuButton>
@@ -98,7 +98,7 @@
 
     <div class="h-[800px] pt-[382px]">
       <Menu>
-        <Float show placement="right" :shift="shift" z-index="99">
+        <Float show placement="right" :shift="shift" z-index="99" transform>
           <MenuButton class="flex justify-center items-center mx-auto px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
             Options
           </MenuButton>
@@ -137,7 +137,7 @@
 
     <div class="h-[800px] pt-[382px]">
       <Menu>
-        <Float show placement="bottom" :flip="flip" z-index="99">
+        <Float show placement="bottom" :flip="flip" z-index="99" transform>
           <MenuButton class="flex justify-center items-center mx-auto px-5 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-500 text-sm rounded-md">
             Options
           </MenuButton>

--- a/packages/react/src/float.tsx
+++ b/packages/react/src/float.tsx
@@ -202,7 +202,7 @@ export function renderFloatingElement(
   const floatingProps = {
     style: {
       // If enable dialog mode, then set `transform` to false.
-      ...((props.dialog ? false : (props.transform || props.transform === undefined)) ? {
+      ...((props.dialog ? false : props.transform) ? {
         position: strategy,
         zIndex: props.zIndex || 9999,
         top: '0px',

--- a/packages/react/test/unit/render-as.test.tsx
+++ b/packages/react/test/unit/render-as.test.tsx
@@ -108,7 +108,7 @@ describe('Render as component for wrapper', () => {
     const wrapper = container.children[1]
     expect(wrapper).toHaveClass('floating-wrapper-class')
     expect(wrapper).toHaveAttribute('data-label', 'floating wrapper label')
-    expect(wrapper).toHaveStyle('position: absolute; z-index: 9999; top: 0px; left: 0px; transform: translate(0px,0px);')
+    expect(wrapper).toHaveStyle('position: absolute; z-index: 9999; top: 0px; left: 0px;')
   })
 })
 
@@ -260,6 +260,6 @@ describe('Render composable component for wrapper', () => {
     const wrapper = container.children[2].children[0]
     expect(wrapper).toHaveClass('floating-wrapper-class')
     expect(wrapper).toHaveAttribute('data-label', 'floating wrapper label')
-    expect(wrapper).toHaveStyle('position: absolute; z-index: 9999; top: 0px; left: 0px; transform: translate(0px,0px);')
+    expect(wrapper).toHaveStyle('position: absolute; z-index: 9999; top: 0px; left: 0px;')
   })
 })

--- a/packages/react/test/unit/ssr.test.tsx
+++ b/packages/react/test/unit/ssr.test.tsx
@@ -61,7 +61,7 @@ describe('SSR', () => {
 
     expect(contents).toContain('button')
     expect(contents).not.toContain('content')
-    expect(contents).toContain('<div style="position:absolute;z-index:9999;top:0px;left:0px;right:auto;bottom:auto;transform:translate(0px,0px)">')
+    expect(contents).toContain('<div style="position:absolute;z-index:9999;top:0px;left:0px">')
   })
 
   it('should to hydrate <Float> with show content', async () => {
@@ -75,7 +75,7 @@ describe('SSR', () => {
 
     expect(contents).toContain('button')
     expect(contents).toContain('content')
-    expect(contents).toContain('<div style="position:absolute;z-index:9999;top:0px;left:0px;right:auto;bottom:auto;transform:translate(0px,0px)">')
+    expect(contents).toContain('<div style="position:absolute;z-index:9999;top:0px;left:0px">')
   })
 
   it('should to hydrate <Float> with not show content', async () => {
@@ -89,6 +89,6 @@ describe('SSR', () => {
 
     expect(contents).toContain('button')
     expect(contents).not.toContain('content')
-    expect(contents).toContain('<div style="position:absolute;z-index:9999;top:0px;left:0px;right:auto;bottom:auto;transform:translate(0px,0px)">')
+    expect(contents).toContain('<div style="position:absolute;z-index:9999;top:0px;left:0px">')
   })
 })

--- a/packages/react/test/unit/virtual-element.test.tsx
+++ b/packages/react/test/unit/virtual-element.test.tsx
@@ -59,7 +59,9 @@ describe('Render virtual elements', () => {
     expect(menu).toBeInTheDocument()
     expect(menu.innerHTML).toContain('Account settings')
     expect(menu.innerHTML).toContain('Documentation')
-    expect(menu.style.transform).toBe('translate(200px,170px)')
+    expect(menu.style.position).toBe('absolute')
+    expect(menu.style.top).toBe('170px')
+    expect(menu.style.left).toBe('200px')
 
     await userEvent.click(button)
     await waitFor()
@@ -83,6 +85,8 @@ describe('Render virtual elements', () => {
 
     const element = screen.getByTestId('content')
     expect(element.innerHTML).toBe('cursor content')
-    expect(element.style.transform).toBe('translate(200px,170px)')
+    expect(element.style.position).toBe('absolute')
+    expect(element.style.top).toBe('170px')
+    expect(element.style.left).toBe('200px')
   })
 })

--- a/packages/vue/src/float.ts
+++ b/packages/vue/src/float.ts
@@ -203,7 +203,7 @@ export const FloatPropsValidators = {
   },
   transform: {
     type: Boolean,
-    default: true,
+    default: false,
   },
   adaptiveWidth: {
     type: Boolean,

--- a/packages/vue/test/unit/render-as.test.ts
+++ b/packages/vue/test/unit/render-as.test.ts
@@ -112,7 +112,7 @@ describe('Render as component for wrapper', () => {
     const wrapper = container.children[1]
     expect(wrapper).toHaveClass('floating-wrapper-class')
     expect(wrapper).toHaveAttribute('data-label', 'floating wrapper label')
-    expect(wrapper).toHaveStyle('position: absolute; z-index: 9999; top: 0px; left: 0px; transform: translate(0px,0px);')
+    expect(wrapper).toHaveStyle('position: absolute; z-index: 9999; top: 0px; left: 0px;')
   })
 })
 
@@ -273,6 +273,6 @@ describe('Render composable component for wrapper', () => {
     const wrapper = container.children[2].children[0]
     expect(wrapper).toHaveClass('floating-wrapper-class')
     expect(wrapper).toHaveAttribute('data-label', 'floating wrapper label')
-    expect(wrapper).toHaveStyle('position: absolute; z-index: 9999; top: 0px; left: 0px; transform: translate(0px,0px);')
+    expect(wrapper).toHaveStyle('position: absolute; z-index: 9999; top: 0px; left: 0px;')
   })
 })

--- a/packages/vue/test/unit/ssr.test.ts
+++ b/packages/vue/test/unit/ssr.test.ts
@@ -19,7 +19,7 @@ describe('SSR', () => {
 
     expect(contents).toContain('button')
     expect(contents).not.toContain('content')
-    expect(contents).toContain('<div style="position:absolute;z-index:9999;top:0px;left:0px;right:auto;bottom:auto;transform:translate(0px,0px);">')
+    expect(contents).toContain('<div style="position:absolute;z-index:9999;top:0px;left:0px;">')
   })
 
   it('should to hydrate <Float> with show content', async () => {
@@ -27,7 +27,7 @@ describe('SSR', () => {
 
     expect(contents).toContain('button')
     expect(contents).toContain('content')
-    expect(contents).toContain('<div style="position: absolute; z-index: 9999; top: 0px; left: 0px; transform: translate(0px,0px);">')
+    expect(contents).toContain('<div style="position: absolute; z-index: 9999; top: 0px; left: 0px;">')
   })
 
   it('should to hydrate <Float> with not show content', async () => {
@@ -35,6 +35,6 @@ describe('SSR', () => {
 
     expect(contents).toContain('button')
     expect(contents).not.toContain('content')
-    expect(contents).toContain('<div style="position: absolute; z-index: 9999; top: 0px; left: 0px; transform: translate(0px,0px);">')
+    expect(contents).toContain('<div style="position: absolute; z-index: 9999; top: 0px; left: 0px;">')
   })
 })

--- a/packages/vue/test/unit/virtual-element.test.ts
+++ b/packages/vue/test/unit/virtual-element.test.ts
@@ -59,7 +59,9 @@ describe('Render virtual elements', () => {
     expect(menu).toBeInTheDocument()
     expect(menu.innerHTML).toContain('Account settings')
     expect(menu.innerHTML).toContain('Documentation')
-    expect(menu.style.transform).toBe('translate(200px,170px)')
+    expect(menu.style.position).toBe('absolute')
+    expect(menu.style.top).toBe('170px')
+    expect(menu.style.left).toBe('200px')
 
     await userEvent.click(button)
     await wait(50)
@@ -84,6 +86,8 @@ describe('Render virtual elements', () => {
 
     const element = screen.getByTestId('content')
     expect(element.innerHTML).toBe('cursor content')
-    expect(element.style.transform).toBe('translate(200px,170px)')
+    expect(element.style.position).toBe('absolute')
+    expect(element.style.top).toBe('170px')
+    expect(element.style.left).toBe('200px')
   })
 })


### PR DESCRIPTION
### Fixed
* Fix blurry text on browser zoom (#54)
* Fixed the issue that the transition of CSS `transform` would not work properly when `floating-as` is set to `template / Fragment`, because the `transform` prop defaults to `true`