### PR TITLE
Add width attribute option for `adaptive-width`

### DIFF
--- a/packages/react/src/float.tsx
+++ b/packages/react/src/float.tsx
@@ -115,7 +115,9 @@ export interface FloatProps {
   tailwindcssOriginClass?: boolean
   portal?: boolean
   transform?: boolean
-  adaptiveWidth?: boolean
+  adaptiveWidth?: boolean | {
+    attribute?: string
+  }
   composable?: boolean
   dialog?: boolean
   middleware?: Middleware[] | ((refs: {
@@ -205,10 +207,18 @@ export function renderFloatingElement(
     style: {
       ...floatingStyles,
       zIndex: props.zIndex || 9999,
-      width: props.adaptiveWidth && typeof referenceElWidth === 'number'
-        ? `${referenceElWidth}px`
-        : undefined,
-    },
+    } as Record<string, any>,
+  }
+
+  if (props.adaptiveWidth && typeof referenceElWidth === 'number') {
+    const adaptiveWidthOptions = {
+      attribute: 'width',
+      ...typeof props.adaptiveWidth === 'object'
+        ? props.adaptiveWidth
+        : {},
+    }
+
+    floatingProps.style[adaptiveWidthOptions.attribute] = `${referenceElWidth}px`
   }
 
   function renderPortal(children: ReactElement) {
@@ -336,7 +346,7 @@ function useFloat(
     }
   }, [middlewareData, props.hide, isPositioned])
 
-  useReferenceElResizeObserver(props.adaptiveWidth, refs.reference, setReferenceElWidth)
+  useReferenceElResizeObserver(!!props.adaptiveWidth, refs.reference, setReferenceElWidth)
 
   useEffect(() => {
     if (refs.reference.current &&

--- a/packages/vue/src/float.ts
+++ b/packages/vue/src/float.ts
@@ -127,7 +127,9 @@ export interface FloatProps {
   tailwindcssOriginClass?: boolean
   portal?: boolean
   transform?: boolean
-  adaptiveWidth?: boolean
+  adaptiveWidth?: boolean | {
+    attribute?: string
+  }
   composable?: boolean
   dialog?: boolean
   middleware?: Middleware[] | ((refs: {
@@ -217,7 +219,7 @@ export const FloatPropsValidators = {
     default: false,
   },
   adaptiveWidth: {
-    type: Boolean,
+    type: [Boolean, Object] as PropType<boolean | { attribute?: string }>,
     default: false,
   },
   composable: {
@@ -335,10 +337,18 @@ export function renderFloatingElement(
     style: {
       ...floatingStyles.value,
       zIndex: props.zIndex,
-      width: props.adaptiveWidth && typeof referenceElWidth.value === 'number'
-        ? `${referenceElWidth.value}px`
-        : undefined,
-    },
+    } as Record<string, any>,
+  }
+
+  if (props.adaptiveWidth && typeof referenceElWidth.value === 'number') {
+    const adaptiveWidthOptions = {
+      attribute: 'width',
+      ...typeof props.adaptiveWidth === 'object'
+        ? props.adaptiveWidth
+        : {},
+    }
+
+    floatingProps.style[adaptiveWidthOptions.attribute] = `${referenceElWidth.value}px`
   }
 
   function renderPortal(node: VNode) {
@@ -506,7 +516,7 @@ export function useFloat<T extends ReferenceElement>(
     arrowY.value = arrowData?.y
   })
 
-  useReferenceElResizeObserver(props.adaptiveWidth, referenceEl, referenceElWidth)
+  useReferenceElResizeObserver(!!props.adaptiveWidth, referenceEl, referenceElWidth)
 
   watch([show, isVisible], async (value, oldValue, onInvalidate) => {
     await nextTick()


### PR DESCRIPTION
close #114

Add width attribute option for `adaptive-width`.

### Usage (React)

```jsx
<Float adaptive-width={{ attribute: 'min-width' }}>
```

### Usage (Vue)

```vue
<Float :adaptive-width="{ attribute: 'min-width' }">
```
